### PR TITLE
Binary rejected Multitasking Apps may only use background services for their intended purposes: VoIP, audio playback, location, task completion, local notifications, etc.

### DIFF
--- a/MEGA.xcodeproj/project.pbxproj
+++ b/MEGA.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		137361901A6664C300B740E8 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 1373618F1A6664C300B740E8 /* main.m */; };
 		137361931A6664C300B740E8 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 137361921A6664C300B740E8 /* AppDelegate.m */; };
 		1373619E1A6664C300B740E8 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1373619D1A6664C300B740E8 /* Images.xcassets */; };
+		410AD3C11C883AA900BF939E /* MEGAAVViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 410AD3C01C883AA900BF939E /* MEGAAVViewController.m */; };
 		411C4C5E1BBEAFB3006FE451 /* CTAssetsPicker.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 411C4C5D1BBEAFB3006FE451 /* CTAssetsPicker.xcassets */; };
 		4122C0E61B274E8C001CE833 /* LocalizationSystem.m in Sources */ = {isa = PBXBuildFile; fileRef = 4122C0E51B274E8C001CE833 /* LocalizationSystem.m */; };
 		412EB2661C6E52AA001EA6D6 /* MEGAAssetOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 412EB2651C6E52AA001EA6D6 /* MEGAAssetOperation.m */; };
@@ -184,6 +185,8 @@
 		410333EF1B99951900380FF3 /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; lineEnding = 0; name = ru; path = ru.lproj/Localizable.strings; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.simpleColoring; };
 		410333F31B99956D00380FF3 /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; lineEnding = 0; name = sv; path = sv.lproj/Localizable.strings; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.simpleColoring; };
 		410333FA1B9995DC00380FF3 /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; lineEnding = 0; name = "zh-Hant"; path = "zh-Hant.lproj/Localizable.strings"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.simpleColoring; };
+		410AD3BF1C883AA900BF939E /* MEGAAVViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MEGAAVViewController.h; sourceTree = "<group>"; };
+		410AD3C01C883AA900BF939E /* MEGAAVViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MEGAAVViewController.m; sourceTree = "<group>"; };
 		411C4C5D1BBEAFB3006FE451 /* CTAssetsPicker.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = CTAssetsPicker.xcassets; path = iMEGA/Vendor/CTAssetsPickerController/Resources/CTAssetsPicker.xcassets; sourceTree = SOURCE_ROOT; };
 		4122C0E41B274E8C001CE833 /* LocalizationSystem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LocalizationSystem.h; path = Vendor/AMLocalizedString/LocalizationSystem.h; sourceTree = "<group>"; };
 		4122C0E51B274E8C001CE833 /* LocalizationSystem.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = LocalizationSystem.m; path = Vendor/AMLocalizedString/LocalizationSystem.m; sourceTree = "<group>"; };
@@ -706,6 +709,8 @@
 				E8C8D73D1B1DCB4000BCDBA4 /* MEGANavigationController.h */,
 				E8C8D73E1B1DCB4000BCDBA4 /* MEGANavigationController.m */,
 				E8C8D7821B219BBA00BCDBA4 /* Animators */,
+				410AD3BF1C883AA900BF939E /* MEGAAVViewController.h */,
+				410AD3C01C883AA900BF939E /* MEGAAVViewController.m */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -1376,6 +1381,7 @@
 				41E566881BBD6160007569A2 /* ALAssetsGroup+isEqual.m in Sources */,
 				E8D4B8921A69429200A3B2E2 /* CreateAccountViewController.m in Sources */,
 				E8F791801BC5754A00C58676 /* OpenInActivity.m in Sources */,
+				410AD3C11C883AA900BF939E /* MEGAAVViewController.m in Sources */,
 				4182B4EF1BF4ADD400E6FFB8 /* ContactRequestsTableViewCell.m in Sources */,
 				4147C2D11B4EE8A400A37044 /* MEGACD.xcdatamodeld in Sources */,
 				E8F791821BC5754A00C58676 /* ShareFolderActivity.m in Sources */,

--- a/iMEGA/Settings/About/AboutTableViewController.m
+++ b/iMEGA/Settings/About/AboutTableViewController.m
@@ -171,7 +171,7 @@
             [[NSUserDefaults standardUserDefaults] setBool:NO forKey:@"logging"];
             [[NSUserDefaults standardUserDefaults] synchronize];
         } else {
-            [MEGASdk setLogLevel:MEGALogLevelDebug];
+            [MEGASdk setLogLevel:MEGALogLevelMax];
             
             freopen([logPath cStringUsingEncoding:NSASCIIStringEncoding],"a+",stderr);
             

--- a/iMEGA/Utils/Helper.h
+++ b/iMEGA/Utils/Helper.h
@@ -26,7 +26,7 @@
 
 #define imagesSet       [[NSSet alloc] initWithObjects:@"gif", @"jpg", @"tif", @"jpeg", @"bmp", @"png",@"nef", nil]
 #define videoSet        [[NSSet alloc] initWithObjects:@"mp4", @"mov", @"m4v", @"3gp", /*@"mkv", @"avi", @"mpg", @"mpeg",@"aaf",*/ nil]
-#define multimediaSet   [[NSSet alloc] initWithObjects:@"mp4", @"mov", @"mp3", @"3gp", @"wav", @"m4v", nil]
+#define multimediaSet   [[NSSet alloc] initWithObjects:@"mp4", @"mov", @"3gp", @"wav", @"m4v", @"m4a", @"mp3", nil]
 
 #define isImage(n)        [imagesSet containsObject:n.lowercaseString]
 #define isVideo(n)        [videoSet containsObject:n.lowercaseString]

--- a/iMEGA/Utils/MEGAAVViewController.h
+++ b/iMEGA/Utils/MEGAAVViewController.h
@@ -1,0 +1,32 @@
+/**
+ * @file MEGAAVViewController.h
+ * @brief This class manages the playback for an AV files/nodes.
+ *
+ * (c) 2013-2015 by Mega Limited, Auckland, New Zealand
+ *
+ * This file is part of the MEGA SDK - Client Access Engine.
+ *
+ * Applications using the MEGA API must present a valid application key
+ * and comply with the the rules set forth in the Terms of Service.
+ *
+ * The MEGA SDK is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * @copyright Simplified (2-clause) BSD License.
+ *
+ * You should have received a copy of the license along with this
+ * program.
+ */
+
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
+#import "MEGASdkManager.h"
+
+@interface MEGAAVViewController : UIViewController
+
+- (instancetype)initWithURL:(NSURL *)path;
+- (instancetype)initWithNode:(MEGANode *)node folderLink:(BOOL)folderLink;
+
+@end

--- a/iMEGA/Utils/MEGAAVViewController.m
+++ b/iMEGA/Utils/MEGAAVViewController.m
@@ -1,0 +1,155 @@
+/**
+ * @file MEGAAVViewController.m
+ * @brief This class manages the playback for an AV files/nodes.
+ *
+ * (c) 2013-2015 by Mega Limited, Auckland, New Zealand
+ *
+ * This file is part of the MEGA SDK - Client Access Engine.
+ *
+ * Applications using the MEGA API must present a valid application key
+ * and comply with the the rules set forth in the Terms of Service.
+ *
+ * The MEGA SDK is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * @copyright Simplified (2-clause) BSD License.
+ *
+ * You should have received a copy of the license along with this
+ * program.
+ */
+
+#import <MediaPlayer/MediaPlayer.h>
+#import "MEGAAVViewController.h"
+#import "MEGAQLPreviewControllerTransitionAnimator.h"
+#import "Helper.h"
+
+@interface MEGAAVViewController () <UIViewControllerTransitioningDelegate>
+
+@property (nonatomic, strong, nonnull) NSURL *path;
+@property (nonatomic, strong) MEGANode *node;
+@property (nonatomic, assign, getter=isFolderLink) BOOL folderLink;
+
+@end
+
+@implementation MEGAAVViewController
+
+- (instancetype)initWithURL:(NSURL *)path {
+    self = [super init];
+    
+    if (self) {
+        _path       = path;
+        _node       = nil;
+        _folderLink = NO;
+    }
+    
+    return self;
+}
+
+- (instancetype)initWithNode:(MEGANode *)node folderLink:(BOOL)folderLink {
+    self = [super init];
+    
+    if (self) {
+        _node       = node;
+        _folderLink = folderLink;
+        if (!folderLink) {
+            _path = [[MEGASdkManager sharedMEGASdk] httpServerGetLocalLink:node];
+        } else {
+            _path = [[MEGASdkManager sharedMEGASdkFolder] httpServerGetLocalLink:node];
+        }
+    }
+    
+    return self;
+}
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    [self setTransitioningDelegate:self];
+    [self play];
+}
+
+- (void)viewWillAppear:(BOOL)animated {
+    [super viewWillAppear:animated];
+}
+
+- (void)play {
+    if (_path) {
+        MPMoviePlayerViewController *moviePlayerViewController = [[MPMoviePlayerViewController alloc] initWithContentURL:_path];
+        [[NSNotificationCenter defaultCenter] addObserver:self
+                                                 selector:@selector(movieFinishedCallback:)
+                                                     name:MPMoviePlayerPlaybackDidFinishNotification
+                                                   object:moviePlayerViewController.moviePlayer];
+        
+        [[NSNotificationCenter defaultCenter] removeObserver:moviePlayerViewController name:UIApplicationDidEnterBackgroundNotification object:nil];
+        
+        if (_node && ![_node hasThumbnail] && ![self isFolderLink] && isVideo(_node.name.pathExtension)) {
+            [[NSNotificationCenter defaultCenter] addObserver:self
+                                                     selector:@selector(handleThumbnailImageRequestFinishNotification:)
+                                                         name:MPMoviePlayerThumbnailImageRequestDidFinishNotification
+                                                       object:moviePlayerViewController.moviePlayer];
+            
+            [[moviePlayerViewController moviePlayer] requestThumbnailImagesAtTimes:@[[NSNumber numberWithFloat:0.0]] timeOption:MPMovieTimeOptionExact];
+        }
+
+        [self.view addSubview:moviePlayerViewController.view];
+        [self addChildViewController:moviePlayerViewController];
+        [moviePlayerViewController didMoveToParentViewController:self];
+        
+        [moviePlayerViewController.moviePlayer prepareToPlay];
+        [moviePlayerViewController.moviePlayer play];
+    }
+}
+
+
+#pragma mark - Movie player
+
+- (void)movieFinishedCallback:(NSNotification*)aNotification {
+    MPMoviePlayerController *moviePlayer = [aNotification object];    
+    [moviePlayer cancelAllThumbnailImageRequests];
+    
+    [[NSNotificationCenter defaultCenter] removeObserver:self
+                                                    name:MPMoviePlayerPlaybackDidFinishNotification
+                                                  object:moviePlayer];
+    [self dismissViewControllerAnimated:YES completion:nil];
+    
+    if (_node) {
+        if (![self isFolderLink]) {
+            [[MEGASdkManager sharedMEGASdk] httpServerStop];
+        } else {
+            [[MEGASdkManager sharedMEGASdkFolder] httpServerStop];
+        }
+    }
+}
+
+- (void)handleThumbnailImageRequestFinishNotification:(NSNotification *)aNotification {
+    MPMoviePlayerController *moviePlayer = [aNotification object];
+    [[NSNotificationCenter defaultCenter] removeObserver:self
+                                                    name:MPMoviePlayerThumbnailImageRequestDidFinishNotification
+                                                  object:moviePlayer];
+    UIImage *image = [moviePlayer thumbnailImageAtTime:0.0 timeOption:MPMovieTimeOptionNearestKeyFrame];
+    
+    NSString *tmpImagePath = [[NSTemporaryDirectory() stringByAppendingPathComponent:_node.base64Handle] stringByAppendingPathExtension:@"jpg"];
+    
+    [UIImageJPEGRepresentation(image, 1) writeToFile:tmpImagePath atomically:YES];
+    
+    NSString *thumbnailFilePath = [Helper pathForNode:_node searchPath:NSCachesDirectory directory:@"thumbnailsV3"];
+    [[MEGASdkManager sharedMEGASdk] createThumbnail:tmpImagePath destinatioPath:thumbnailFilePath];
+    [[MEGASdkManager sharedMEGASdk] setThumbnailNode:_node sourceFilePath:thumbnailFilePath];
+    
+    NSString *previewFilePath = [Helper pathForNode:_node searchPath:NSCachesDirectory directory:@"previewsV3"];
+    [[MEGASdkManager sharedMEGASdk] createPreview:tmpImagePath destinatioPath:previewFilePath];
+    [[MEGASdkManager sharedMEGASdk] setPreviewNode:_node sourceFilePath:previewFilePath];
+    
+    [[NSFileManager defaultManager] removeItemAtPath:tmpImagePath error:nil];
+}
+
+#pragma mark - UIViewControllerTransitioningDelegate
+
+- (id<UIViewControllerAnimatedTransitioning>)animationControllerForPresentedController:(UIViewController *)presented presentingController:(UIViewController *)presenting sourceController:(UIViewController *)source {
+    if ([presented isKindOfClass:[MPMoviePlayerViewController class]]) {
+        return [[MEGAQLPreviewControllerTransitionAnimator alloc] init];
+    }
+    return nil;
+}
+
+@end


### PR DESCRIPTION
2.16. Multitasking Apps may only use background services for their intended purposes: VoIP, audio playback, location, task completion, local notifications, etc.

The client can not reproduce audio / video offline files in background because the app uses QLPreviewController. Change from QLPreviewController to MPMoviePlayerViewController.
