### PR TITLE
fixed grammar error in ru localisation

### DIFF
--- a/iMEGA/Languages/ru.lproj/InfoPlist.strings
+++ b/iMEGA/Languages/ru.lproj/InfoPlist.strings
@@ -3,9 +3,9 @@
 /* Camera usage description. To protect user privacy Apple requires a purpose string explaining why will be accessed. */
 "NSCameraUsageDescription"="MEGA обращается к вашей камере, когда вы снимаете видео, фотографируете или звоните внутри приложения.";
 /* Photo library usage description. To protect user privacy Apple requires a purpose string explaining why will be accessed. */
-"NSPhotoLibraryUsageDescription"="MEGA получает доступ к вашим фото и видео, когда вы загружаете их, делитесь в чате, и когда включены Загрузки из камеры.";
+"NSPhotoLibraryUsageDescription"="MEGA получает доступ к вашим фото и видео, когда вы загружаете их, делитесь в чате, и когда включены загрузки из камеры.";
 /* Contacts Usage Description. To protect user privacy Apple requires a purpose string explaining why will be accessed. */
-"NSContactsUsageDescription"="Если вы разрешить, вы сможете пригласить свои контакты в MEGA, отправив им сообщение или электронное письмо.";
+"NSContactsUsageDescription"="Если вы дадите разрешение, вы сможете пригласить свои контакты в MEGA, отправив им сообщение или электронное письмо.";
 /* Write-only access to the user’s photo library description. To protect user privacy Apple requires a purpose string explaining why will be accessed. */
 "NSPhotoLibraryAddUsageDescription"="MEGA требуется доступ к вашей фотобиблиотеке, чтобы добавлять фото и видео в галерею устройства";
 /* Face ID usage description. To protect user privacy Apple requires a purpose string explaining why will be accessed. */


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
Fixed a grammar mistake in ru infoPlist strings file.
Rough translation:
The original version was: "If you to allow... you will be able to invite";
The new version: "If you give permission... you will be able to..."

|         Before         |           After         |
| <img src="blob:https://mega.nz/bf570087-6652-4073-9e7e-502a68851ccf" width=320> | <img src="blob:https://mega.nz/bf570087-6652-4073-9e7e-502a68851ccf" width=320>  | 

Does this close any currently open issues?
No

Any relevant logs, error output, etc?
No

Any other comments?
Also fixed capitalisation in the other string. It was supposed to be lowercase instead of uppercase 
…

Where has this been tested?
---------------------------
**Devices/Simulators:** …

**iOS Version:** …

**MEGA Version:** 
