### PR TITLE
fix: Question1 And Question2

### DIFF
--- a/iMEGA/Utils/Shared Views/Shared Controls/MEGAAVViewController.h
+++ b/iMEGA/Utils/Shared Views/Shared Controls/MEGAAVViewController.h
@@ -14,6 +14,7 @@
 @property (nonatomic, strong, nullable) NSURL *fileUrl;
 @property (nonatomic, strong, nullable) MEGASdk *apiForStreaming;
 @property (nonatomic, assign) BOOL isFolderLink;
+@property (nonatomic, strong) dispatch_queue_t _Nonnull playerQueue;
 
 - (instancetype _Nonnull)initWithURL:(NSURL *_Nonnull)fileUrl;
 - (instancetype _Nonnull)initWithNode:(MEGANode * _Nonnull)node folderLink:(BOOL)folderLink apiForStreaming:(MEGASdk * _Nonnull)apiForStreaming;

--- a/iMEGA/Utils/SwiftUI/SearchBarUIHostingController/SearchBarUIHostingController.swift
+++ b/iMEGA/Utils/SwiftUI/SearchBarUIHostingController/SearchBarUIHostingController.swift
@@ -23,6 +23,21 @@ class SearchBarUIHostingController<Content>: UIHostingController<Content>, Audio
     private weak var audioPlayerManager: (any AudioPlayerHandlerProtocol)?
     private var selectionModeEnabled = false
     
+    // 状态管理
+    private let stateQueue = DispatchQueue(label: "com.mega.searchbar.state", qos: .userInitiated)
+    private let stateLock = NSLock()
+    private var pendingUpdates: [() -> Void] = []
+    private var cleanupTasks: [() -> Void] = []
+    
+    private enum ViewState {
+        case initializing
+        case ready
+        case disappearing
+        case disposed
+    }
+    
+    private var viewState: ViewState = .initializing
+    
     init(
         rootView: Content,
         wrapper: SearchControllerWrapper,
@@ -42,10 +57,25 @@ class SearchBarUIHostingController<Content>: UIHostingController<Content>, Audio
         self.matchingNodeProvider = matchingNodeProvider
         self.audioPlayerManager = audioPlayerManager
         super.init(rootView: rootView)
+        
+        setupInitialState()
     }
     
     @MainActor required dynamic init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        viewState = .ready
+        processPendingUpdates()
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        viewState = .disappearing
+        removeToolbar(animated: false)
+        cleanSearchController()
     }
     
     override func viewDidLoad() {
@@ -103,15 +133,44 @@ class SearchBarUIHostingController<Content>: UIHostingController<Content>, Audio
         removeToolbar(animated: animated)
     }
     
+    private func setupInitialState() {
+        addCleanupTask { [weak self] in
+            self?.wrapper?.onUpdateSearchBarVisibility = nil
+            self?.selectionHandler?.onSelectionModeChange = nil
+            self?.selectionHandler?.onSelectionChanged = nil
+            self?.browseDelegate.endEditingMode = nil
+        }
+    }
+    
+    private func updateState(_ update: @escaping () -> Void) {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        
+        if viewState == .ready {
+            DispatchQueue.main.async {
+                update()
+            }
+        } else {
+            pendingUpdates.append(update)
+        }
+    }
+    
+    private func processPendingUpdates() {
+        stateQueue.async { [weak self] in
+            guard let self = self else { return }
+            let updates = self.pendingUpdates
+            self.pendingUpdates.removeAll()
+            
+            DispatchQueue.main.async {
+                updates.forEach { $0() }
+            }
+        }
+    }
+    
     deinit {
         CrashlyticsLogger.log(category: .viewLifecycle, "SearchBarUIHostingController deinit - Before removeToolbar")
-        
-        wrapper?.onUpdateSearchBarVisibility = nil
-        selectionHandler?.onSelectionModeChange = nil
-        selectionHandler?.onSelectionChanged = nil
-        browseDelegate.endEditingMode = nil
-        
-        navigationItem.searchController = nil
+
+        cleanup()
         
         CrashlyticsLogger.log(category: .viewLifecycle, "SearchBarUIHostingController deinit.")
     }
@@ -121,23 +180,46 @@ class SearchBarUIHostingController<Content>: UIHostingController<Content>, Audio
         wrapper?.cancelSearch()
     }
     
-    // MARK: - AudioPlayerPresenterProtocol
-    public func updateContentView(_ height: CGFloat) {
-        additionalSafeAreaInsets = .init(top: 0, left: 0, bottom: height, right: 0)
+    // MARK: - UI Updates
+    private func updateSearchBarVisibility(_ isVisible: Bool) {
+        updateState { [weak self] in
+            guard let self = self else { return }
+            self.searchBarVisible = isVisible
+            if isVisible {
+                self.wrapper?.attachToViewController(self)
+            } else {
+                self.navigationItem.searchController = nil
+            }
+        }
     }
     
-    public func hasUpdatedContentView() -> Bool {
-        additionalSafeAreaInsets.bottom != 0
+    private func updateSelectionMode(_ enabled: Bool, config: BottomToolbarConfig) {
+        updateState { [weak self] in
+            guard let self = self else { return }
+            self.selectionModeEnabled = enabled
+            
+            if enabled {
+                self.addToolbar(for: config, animated: true)
+            } else {
+                self.removeToolbar(animated: true)
+            }
+            
+            if let audioPlayerManager = self.audioPlayerManager,
+               audioPlayerManager.isPlayerAlive() {
+                audioPlayerManager.playerHidden(enabled, presenter: self)
+            }
+        }
     }
-    
-    // MARK: - Private methods
     
     private func updateToolbar(with config: BottomToolbarConfig) {
-        configureToolbar(with: config)
+        updateState { [weak self] in
+            self?.configureToolbar(with: config)
+        }
     }
     
+    // MARK: - Toolbar Management
     private func configureToolbar(with config: BottomToolbarConfig) {
-        guard let toolbar else { return }
+        guard let toolbar = toolbar else { return }
         let items = toolbarBuilder.buildToolbarItems(
             config: config,
             parent: self,
@@ -145,55 +227,103 @@ class SearchBarUIHostingController<Content>: UIHostingController<Content>, Audio
         )
         
         let flexibleItem = UIBarButtonItem(systemItem: .flexibleSpace)
-        
-        // insert flexibleItem to make all items evenly distributed
         toolbar.items = items.flatMap { if $0 == items.last { [$0] } else { [$0, flexibleItem] } }
     }
     
     private func removeToolbar(animated: Bool) {
-        guard self.toolbar?.superview != nil else { return }
-        
-        guard animated else {
-            self.toolbar?.removeFromSuperview()
-            return
-        }
-        
-        UIView.animate(
-            withDuration: 0.33,
-            animations: {
-                self.toolbar?.alpha = 0
-            },
-            completion: { _ in
-                self.toolbar?.removeFromSuperview()
+        updateState { [weak self] in
+            guard let self = self, let toolbar = self.toolbar else { return }
+            
+            if animated {
+                UIView.animate(
+                    withDuration: 0.33,
+                    animations: {
+                        toolbar.alpha = 0
+                    },
+                    completion: { _ in
+                        toolbar.removeFromSuperview()
+                    }
+                )
+            } else {
+                toolbar.removeFromSuperview()
             }
-        )
+        }
     }
     
     private func addToolbar(for config: BottomToolbarConfig, animated: Bool = false) {
-        guard let toolbar else { return }
-        
-        toolbar.alpha = 0
-        configureToolbar(with: config)
-        
-        tabBarController?.view.addSubview(toolbar)
-        toolbar.translatesAutoresizingMaskIntoConstraints = false
-        
-        if let tabBar = tabBarController?.tabBar {
-            NSLayoutConstraint.activate([
-                toolbar.topAnchor.constraint(equalTo: tabBar.topAnchor, constant: 0),
-                toolbar.leadingAnchor.constraint(equalTo: tabBar.leadingAnchor, constant: 0),
-                toolbar.trailingAnchor.constraint(equalTo: tabBar.trailingAnchor, constant: 0),
-                toolbar.bottomAnchor.constraint(equalTo: tabBar.safeAreaLayoutGuide.bottomAnchor, constant: 0)
-            ])
-        }
-        
-        UIView.animate(
-            withDuration: animated ? 0.33 : 0,
-            animations: {
-                toolbar.alpha = 1
+        updateState { [weak self] in
+            guard let self = self, let toolbar = self.toolbar else { return }
+            
+            toolbar.alpha = 0
+            self.configureToolbar(with: config)
+            
+            self.tabBarController?.view.addSubview(toolbar)
+            toolbar.translatesAutoresizingMaskIntoConstraints = false
+            
+            if let tabBar = self.tabBarController?.tabBar {
+                NSLayoutConstraint.activate([
+                    toolbar.topAnchor.constraint(equalTo: tabBar.topAnchor, constant: 0),
+                    toolbar.leadingAnchor.constraint(equalTo: tabBar.leadingAnchor, constant: 0),
+                    toolbar.trailingAnchor.constraint(equalTo: tabBar.trailingAnchor, constant: 0),
+                    toolbar.bottomAnchor.constraint(equalTo: tabBar.safeAreaLayoutGuide.bottomAnchor, constant: 0)
+                ])
             }
-        )
+            
+            UIView.animate(
+                withDuration: animated ? 0.33 : 0,
+                animations: {
+                    toolbar.alpha = 1
+                }
+            )
+        }
     }
+    
+    // MARK: - Cleanup
+    private func addCleanupTask(_ task: @escaping () -> Void) {
+        cleanupTasks.append(task)
+    }
+    
+    private func cleanup() {
+        cleanupTasks.forEach { $0() }
+        cleanupTasks.removeAll()
+    }
+    
+    // MARK: - Public Methods
+    func cleanSearchController() {
+        wrapper?.cancelSearch()
+        navigationItem.searchController = nil
+    }
+    
+    // MARK: - AudioPlayerPresenterProtocol
+    public func updateContentView(_ height: CGFloat) {
+        updateState { [weak self] in
+            self?.additionalSafeAreaInsets = .init(top: 0, left: 0, bottom: height, right: 0)
+        }
+    }
+    
+    public func hasUpdatedContentView() -> Bool {
+        additionalSafeAreaInsets.bottom != 0
+    }
+    
+    /**
+     ```text
+     0  libdispatch.dylib              0x5508 _dispatch_assert_queue_fail + 120
+     1  libdispatch.dylib              0x371a8 dispatch_assert_queue$V2.cold.2 + 114
+     2  libdispatch.dylib              0x548c dispatch_assert_queue + 108
+     3  UIKitCore                      0x110c38 -[UIImageView _mainQ_beginLoadingIfApplicable] + 76
+     4  UIKitCore                      0x110b28 -[UIImageView setHidden:] + 68
+     ```
+     ### 崩苦分析
+     分析可能的原因：
+     - 溃发生在 `com.apple.SwiftUI.AsyncRenderer` 线程中，崩溃的根本原因就是没有在主线程更新了`UIImageView`这个UI组件，在Pro、Max、Plus机型上会偶现，推测是他们屏幕大或者分辨率高，在ToolBar或NavigationBar上面可以有更多的按钮，导致异步渲染的负载更大，状态更新时更容易出现竞态条件，特别是如果快速切换视图状态下
+     - `SwiftUI`和`UIKit`的生命周期不同步，在`UIKit`的视图释放的时候可能SwiftUI因为状态更新还在更新视图，导致异常
+     
+     ### 解决方案
+     - 确保所有的UI操作都在主线程执行
+     - 尽量不要在deinit做引用self的操作，销毁过程中，涉及到UIKit和SwiftUI的释放，可能会出现访问野指针的情况
+     - 同步UIKit和SwiftUI的生命周期状态，尽量做到同步
+     
+     */
 }
 
 // responsible for communicating selected state and selected items


### PR DESCRIPTION
(Thanks for sending a pull request! Please fill out the blanks below.)

What does this implement/fix? Explain your changes.
---------------------------------------------------

|         Before         |           After         |
| ---------------------- | ----------------------- |
| <img src="" width=320> | <img src="" width=320>  | 


Any other comments?
-------------------
## Question 1:
```text
     0  libdispatch.dylib              0x5508 _dispatch_assert_queue_fail + 120
     1  libdispatch.dylib              0x371a8 dispatch_assert_queue$V2.cold.2 + 114
     2  libdispatch.dylib              0x548c dispatch_assert_queue + 108
     3  UIKitCore                      0x110c38 -[UIImageView _mainQ_beginLoadingIfApplicable] + 76
     4  UIKitCore                      0x110b28 -[UIImageView setHidden:] + 68
     ```
     ### 崩苦分析
     分析可能的原因：
     - 溃发生在 `com.apple.SwiftUI.AsyncRenderer` 线程中，崩溃的根本原因就是没有在主线程更新了`UIImageView`这个UI组件，在Pro、Max、Plus机型上会偶现，推测是他们屏幕大或者分辨率高，在ToolBar或NavigationBar上面可以有更多的按钮，导致异步渲染的负载更大，状态更新时更容易出现竞态条件，特别是如果快速切换视图状态下
     - `SwiftUI`和`UIKit`的生命周期不同步，在`UIKit`的视图释放的时候可能SwiftUI因为状态更新还在更新视图，导致异常
     
     ### 解决方案
     - 确保所有的UI操作都在主线程执行
     - 尽量不要在deinit做引用self的操作，销毁过程中，涉及到UIKit和SwiftUI的释放，可能会出现访问野指针的情况
     - 同步UIKit和SwiftUI的生命周期状态，尽量做到同步
     
 ## Question2
  从trace和图中可以看出，Hang的原因就是调用`seekToDestination`方法，从代码中很容易看出，这个方法是通过url加载音频或者视频，`seekToDestination`的下一个调用栈为 `[AVPlayerViewController setPlayer]`
 
 ### Hang分析
 ```Objective-C
 AVAsset *asset = [AVAsset assetWithURL:self.fileUrl];
 AVPlayerItem *playerItem = [AVPlayerItem playerItemWithAsset:asset];
 ```
 这两行本身都是同步的，但是`fileUrl`如果指向的是一个很大的本地资源或者远程资源，就会导致这个同步方法阻塞线程，从堆栈信息看`seekToDestination` 是在 `viewDidAppear`之后调用的，没有特殊指定线程，则默认会在主线程调用，就会导致阻塞主线程，从而被系统判定为Hang
 
 ### 解决方案
 1. 把`seekToDestination`给放到后台线程去执行，只在关键的调用转回主线程
 2. 使用 `AVURLAsset` 的异步加载，并通过 `status` 来判断是否能够播放
